### PR TITLE
Install and config Prometheus to save Alluxio metrics into Prometheus

### DIFF
--- a/Databricks/Dockerfile
+++ b/Databricks/Dockerfile
@@ -222,6 +222,16 @@ RUN wget -O /tmp/$ALLUXIO_TAR_FILE ${ALLUXIO_DOWNLOAD_URL} \
     && cp ${ALLUXIO_HOME}/client/alluxio-${ALLUXIO_VERSION}-client.jar /databricks/jars/
 
 #############
+# Setup Prometheus
+#############
+ARG PROMETHEUS_VERSION=2.37.3
+ARG PROMETHEUS_TAR_FILE=prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz
+ARG PROMETHEUS_DOWNLOAD_URL=https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/${PROMETHEUS_TAR_FILE}
+RUN wget -O /tmp/${PROMETHEUS_TAR_FILE} ${PROMETHEUS_DOWNLOAD_URL} \
+    && tar zxf /tmp/${PROMETHEUS_TAR_FILE} -C /opt/ \
+    && rm -f /tmp/${PROMETHEUS_TAR_FILE}
+
+#############
 # Allow ubuntu user to sudo without password
 #############
 RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \

--- a/Databricks/README.md
+++ b/Databricks/README.md
@@ -111,7 +111,7 @@ spark.rapids.sql.multiThreadedRead.numThreads 40
 
   - To copy the Alluxio Master and Worker logs off of local disk to be able to look at them after the cluster is shutdown you can configure this to some path accessible via rsync.  For instance, on Databricks this might be a path in /dbfs/.  `ALLUXIO_COPY_LOG_PATH=/dbfs/somedirectory-for-alluxio-logs/`
 
-  - To copy the Alluxio metrics which are in Prometheus format to be able to look at them after the cluster is shutdown you can configure this to some path accessible via rsync. For instance, on Databricks this might be a path in /dbfs/.  `PROMETHEUS_COPY_DATA_PATH=/dbfs/somedirectory-for-alluxio-prometheus-metrics/`. The saved Prometheus data can be graphed outside of the cluster. 
+  - To copy the Alluxio metrics which are in Prometheus format to be able to look at them after the cluster is shutdown you can configure this to some path accessible via rsync. For instance, on Databricks this might be a path in /dbfs/.  `PROMETHEUS_COPY_DATA_PATH=/dbfs/somedirectory-for-alluxio-prometheus-metrics/`. The saved Prometheus data can be graphed outside of the cluster. For more details, refer to `spark-rapids/docs/get-started/getting-started-alluxio.md` in [spark-rapids doc](https://github.com/NVIDIA/spark-rapids)
 
 6. Click `Confirm` (if the cluster is currently stopped) or `Confirm and Restart` if the cluster is currently running.
 

--- a/Databricks/README.md
+++ b/Databricks/README.md
@@ -109,11 +109,13 @@ spark.rapids.sql.multiThreadedRead.numThreads 40
 
   - The default heap size used by the Alluxio Master process is 16GB, this may need to be changed depending on the size of the driver node. Make sure it has enough memory for the Master and the Spark driver processes.  `ALLUXIO_MASTER_HEAP=16g`
 
-  - To copy the Alluxio Master and Worker logs off of local disk to be able to look at them after the cluster is shutdown you can configure this to some path accessible via rsync.  For instance, on Databricks this might be a path in /dbfs/.  `ALLUXIO_COPY_LOG_PATH=/dbfs/somedirectory/`
+  - To copy the Alluxio Master and Worker logs off of local disk to be able to look at them after the cluster is shutdown you can configure this to some path accessible via rsync.  For instance, on Databricks this might be a path in /dbfs/.  `ALLUXIO_COPY_LOG_PATH=/dbfs/somedirectory-for-alluxio-logs/`
 
-5. Click `Confirm` (if the cluster is currently stopped) or `Confirm and Restart` if the cluster is currently running.
+  - To copy the Alluxio metrics which are in Prometheus format to be able to look at them after the cluster is shutdown you can configure this to some path accessible via rsync. For instance, on Databricks this might be a path in /dbfs/.  `PROMETHEUS_COPY_DATA_PATH=/dbfs/somedirectory-for-alluxio-prometheus-metrics/`. The saved Prometheus data can be graphed outside of the cluster. 
 
-6. Ensure the cluster is started by click `Start` if necessary.
+6. Click `Confirm` (if the cluster is currently stopped) or `Confirm and Restart` if the cluster is currently running.
+
+7. Ensure the cluster is started by click `Start` if necessary.
 
 To verify the alluxio cluster is working, you can use the Web Terminal:
 


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/6463

Saving all the metrics as CSV files adds disk load.  
After browsing the Alluxio code, there are no configures to exclude metrics to reduce the IO consumption.  
Saving the metrics into Prometheus is a good solution. Because one HTTP request will get all the metrics at one time.  
This significantly reduces the IO consumption compared to writing about 300 CSV metric files.  
And after we saved the Prometheus-typed metrics data, we can graph the data outside of the Databricks cluster.  

This [PR](https://github.com/NVIDIA/spark-rapids/pull/7172) describes how to graph the data outside of Databricks cluster.  

TODO, see the comments in the code, do not know how to get the worker IPs on the master node.
Maybe we can skip collecting the metrics from worker nodes.

Signed-off-by: Chong Gao <res_life@163.com>