### PR TITLE
Add GPU metrics to Databricks Docker Container

### DIFF
--- a/Databricks/Dockerfile
+++ b/Databricks/Dockerfile
@@ -109,10 +109,19 @@ RUN chmod 755 /opt/spark-rapids/init.sh
 
 WORKDIR /databricks
 
+FROM ubuntu:18.04 as download-modpython
+
+RUN cd /tmp && \
+  apt-get -y update && \
+  apt-get -y download libganglia1 && \
+  ls -al
+
 #############
 # Setup Ganglia
 #############
 FROM with-plugin as with-ganglia
+
+ARG GANGLIA_WEBROOT=/usr/share/ganglia-webfrontend
 
 WORKDIR /databricks
 ENV DEBIAN_FRONTEND=noninteractive
@@ -120,6 +129,7 @@ RUN apt-get update && apt-get install -q -y --force-yes --fix-missing --ignore-m
         ganglia-monitor \
         ganglia-webfrontend \
         ganglia-monitor-python \
+        libpython2.7 \
         python3-pip \
         wget \
         rsync \
@@ -143,6 +153,13 @@ RUN cd /tmp \
   && tar xvjf $PHANTOM_JS.tar.bz2 \
   && mv $PHANTOM_JS /usr/local/share \
   && ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+# Install ganglia modpython
+COPY --from=download-modpython /tmp/libganglia1_*.deb /tmp
+RUN cd /tmp \
+  && mkdir -p /tmp/libganglia1 \
+  && dpkg-deb -xv libganglia1_*.deb /tmp/libganglia1 \
+  && cp /tmp/libganglia1/usr/lib/ganglia/modpython.so /usr/lib/ganglia/ \
+  && rm -rf /tmp/libganglia1
 # Apache2 config. The `sites-enabled` config files are loaded into the container
 # later.
 RUN rm /etc/apache2/sites-enabled/* && a2enmod proxy && a2enmod proxy_http
@@ -173,15 +190,24 @@ check process spark-slave with pidfile /tmp/spark-root-org.apache.spark.deploy.w
 RUN mkdir -p /etc/apache2/sites-enabled
 ADD ganglia/ganglia.conf /etc/apache2/sites-enabled
 RUN chmod 775 /etc/apache2/sites-enabled/ganglia.conf
-ADD ganglia/gconf/* /etc/ganglia/
+ADD ganglia/gconf/*.conf /etc/ganglia/
 RUN mkdir -p /databricks/spark/scripts/ganglia/
 RUN mkdir -p /databricks/spark/scripts/
+RUN mkdir -p $GANGLIA_WEBROOT/graph.d
 ADD ganglia/start_spark_slave.sh /databricks/spark/scripts/start_spark_slave.sh
 
 # add local monit shell script in the right location
 RUN mkdir -p /etc/init.d
 ADD scripts/monit /etc/init.d
 RUN chmod 775 /etc/init.d/monit
+
+# For GPU monitoring in Ganglia, you need the modules available here:
+# https://github.com/ganglia/gmond_python_modules/tree/master/gpu/nvidia/python_modules
+ADD ganglia/gconf/conf.d/* /etc/ganglia/conf.d/
+ADD ganglia/python_modules/* /usr/lib/ganglia/python_modules
+RUN /usr/bin/pip install --upgrade  -t /usr/lib/ganglia/python_modules/ nvidia-ml-py
+
+# Copy the files needed for GPU monitoring in Ganglia
 
 #############
 # Set up webterminal ssh

--- a/Databricks/Dockerfile
+++ b/Databricks/Dockerfile
@@ -109,6 +109,12 @@ RUN chmod 755 /opt/spark-rapids/init.sh
 
 WORKDIR /databricks
 
+# libganglia1 in ubuntu 20.04 actually is missing the modpython.so library
+# needed for the GPU metrics plugin 
+# this is actually a known packaging bug in Ubuntu
+# See https://bugs.launchpad.net/ubuntu/+source/ganglia/+bug/1894045
+# Therefore we need to download the package from Ubuntu 18.04 (which includes 
+# the missing library)
 FROM ubuntu:18.04 as download-modpython
 
 RUN cd /tmp && \
@@ -153,7 +159,7 @@ RUN cd /tmp \
   && tar xvjf $PHANTOM_JS.tar.bz2 \
   && mv $PHANTOM_JS /usr/local/share \
   && ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
-# Install ganglia modpython
+# Install ganglia modpython from Ubuntu 18.04
 COPY --from=download-modpython /tmp/libganglia1_*.deb /tmp
 RUN cd /tmp \
   && mkdir -p /tmp/libganglia1 \

--- a/Databricks/ganglia/gconf/conf.d/gpu.pyconf
+++ b/Databricks/ganglia/gconf/conf.d/gpu.pyconf
@@ -1,0 +1,142 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+modules {
+    module {
+        name = "nvidia"
+        language = "python"
+        params = "/usr/lib/ganglia/python_modules"
+    }
+}
+
+/* This collection group will send general info about the GPU every 300 secs.
+   This information doesn't change between reboots and is only collected once. */
+collection_group {
+    collect_once = yes
+    time_threshold = 300
+    metric {
+        name = "gpu_num"
+        title = "Number of GPUs"
+    }
+    metric {
+        name = "gpu_use_num"
+        title = "Number of GPUs in Use"
+    }
+    metric {
+        name = "gpu_driver"
+        title = "GPU Driver Version"
+    }
+    metric {
+        name = "gpu0_type"
+        title = "GPU Device Name"
+    }
+    metric {
+        name = "gpu0_mem_total"
+        title = "GPU Total Memory"
+    }
+    metric {
+        name = "gpu0_perf_state"
+        title = "GPU Performance State"
+    }
+    metric {
+        name = "gpu0_ecc_mode"
+        title = "GPU ECC Mode"
+    }
+    metric {
+        name = "gpu0_power_man_mode"
+        title = "GPU Power Management Mode"
+    }
+    metric {
+        name = "gpu0_power_man_limit"
+        title = "GPU Power Management Limit"
+    }
+    metric {
+        name = "gpu0_shutdown_temp"
+        title = "GPU Shutdown Temperature"
+    }
+    metric {
+        name = "gpu0_slowdown_temp"
+        title = "GPU Slowdown Temperature"
+    }
+    metric {
+        name = "gpu0_bar1_max_memory"
+        title = "GPU BAR1 Total Memory"
+    }
+    metric {
+        name = "gpu0_serial"
+        title = "GPU Serial Number"
+    }
+}
+
+
+/* This collection group will collect the GPU status info every 20 secs.
+   The time threshold is set to 90 seconds.  In honesty, this time_threshold could be
+   set significantly higher to reduce unneccessary network chatter. */
+collection_group {
+    collect_every = 20
+    time_threshold = 90
+    /* GPU status */
+    metric {
+        name = "gpu0_util"
+        title = "GPU Utilization"
+    }
+    metric {
+        name = "gpu0_mem_util"
+        title = "GPU Memory Utilization"
+    }
+    metric {
+        name = "gpu0_fb_memory"
+        title = "GPU Framebuffer Memory Utilization"
+    }
+    metric {
+        name = "gpu0_graphics_clock_report"
+        title = "GPU Graphics Clock"
+    }
+    metric {
+        name = "gpu0_mem_clock_report"
+        title = "GPU Memory Clock"
+    }
+    metric {
+        name = "gpu0_sm_clock_report"
+        title = "GPU SM Clock"
+    }
+    metric {
+        name = "gpu0_power_usage_report"
+        title = "GPU Power Usage"
+    }
+    metric {
+        name = "gpu0_power_violation_report"
+        title = "GPU Power Violation"
+    }
+    metric {
+        name = "gpu0_encoder_util"
+        title = "GPU Encoder Utilization"
+    }
+    metric {
+        name = "gpu0_decoder_util"
+        title = "GPU Decoder Utilization"
+    }
+    metric {
+        name = "gpu0_temp"
+        title = "GPU Temperature"
+    }
+    metric {
+        name = "gpu0_process"
+        title = "Number of GPU Running Processes"
+    }
+    metric {
+        name = "gpu0_bar1_memory"
+        title = "GPU BAR1 Memory Usage"
+    }
+}

--- a/Databricks/ganglia/python_modules/nvidia.py
+++ b/Databricks/ganglia/python_modules/nvidia.py
@@ -1,0 +1,276 @@
+# NVIDIA GPU metric module using the Python bindings for NVML
+#
+# (C)opyright 2011, 2012 Bernard Li <bernard@vanhpc.org>
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import datetime
+from pynvml import *
+from random import randint
+import time
+
+descriptors = list()
+
+device = 0
+eventSet = 0
+violation_dur = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+'''Return the descriptor based on the name'''
+def find_descriptor(name):
+    for d in descriptors:
+        if d['name'] == name:
+            return d
+
+'''Build descriptor from arguments and append it to the global descriptors list if call_back does not return with error'''
+def build_descriptor(name, call_back, time_max, value_type, units, slope, format, description, groups):
+    d = {'name': name,
+        'call_back': call_back,
+        'time_max': time_max,
+        'value_type': value_type,
+        'units': units,
+        'slope': slope,
+        'format': format,
+        'description': description,
+        'groups': groups,
+        }
+
+    try:
+        call_back(name)
+        descriptors.append(d)
+    except NVMLError, err:
+        print "Failed to build descriptor :", name, ":", str(err)
+        pass
+    except NameError, err:
+        print "Failed to build descriptor :", name, ":", str(err)
+        pass
+
+def get_gpu_num():
+    return int(nvmlDeviceGetCount())
+def get_gpu_use_num(name):
+    use_num = 0
+    for i in range(get_gpu_num()):
+         is_use = gpu_device_handler('gpu%s_process' %i)
+         if(int(is_use)):
+            use_num += 1
+    return use_num
+
+def gpu_num_handler(name):
+    return get_gpu_num()
+
+def gpu_driver_version_handler(name):
+    return nvmlSystemGetDriverVersion()
+
+def gpu_get_device_by_name(name):
+    d = find_descriptor(name)
+    (gpu, metric) = name.split('_', 1)
+    gpu_id = int(gpu.split('gpu')[1])
+    gpu_device = nvmlDeviceGetHandleByIndex(gpu_id)
+    return gpu_device
+
+def gpu_device_handler(name):
+    global violation_dur, violation_rate
+    (gpu, metric) = name.split('_', 1)
+    gpu_id = int(gpu.split('gpu')[1])
+    gpu_device = gpu_get_device_by_name(name)
+
+    if (metric == 'type'):
+        return nvmlDeviceGetName(gpu_device)
+    elif (metric == 'uuid'):
+        return nvmlDeviceGetUUID(gpu_device)
+    elif (metric == 'pci_id'):
+        return nvmlDeviceGetPciInfo(gpu_device).pciDeviceId
+    elif (metric == 'temp'):
+        return nvmlDeviceGetTemperature(gpu_device, NVML_TEMPERATURE_GPU)
+    elif (metric == 'mem_total'):
+        return int(nvmlDeviceGetMemoryInfo(gpu_device).total/(1024*1024))
+    elif (metric == 'fb_memory'):
+        return int(nvmlDeviceGetMemoryInfo(gpu_device).used/1048576)
+    elif (metric == 'util'):
+        return nvmlDeviceGetUtilizationRates(gpu_device).gpu
+    elif (metric == 'mem_util'):
+        return nvmlDeviceGetUtilizationRates(gpu_device).memory
+    elif (metric == 'fan'):
+        try:
+            return nvmlDeviceGetFanSpeed(gpu_device)
+        except NVMLError, nvmlError:
+            # Not all GPUs have fans - a fatal error would not be appropriate
+            if NVML_ERROR_NOT_SUPPORTED == nvmlError.value:
+                return 0
+    elif (metric == 'ecc_mode'):
+        try:
+            ecc_mode = nvmlDeviceGetPendingEccMode(gpu_device)
+            if (NVML_FEATURE_DISABLED == ecc_mode):
+                return "OFF"
+            elif (NVML_FEATURE_ENABLED == ecc_mode):
+                return "ON"
+            else:
+                return "UNKNOWN"
+        except NVMLError, nvmlError:
+            if NVML_ERROR_NOT_SUPPORTED == nvmlError.value:
+                return 'N/A'
+    elif (metric == 'perf_state' or metric == 'performance_state'):
+        state = nvmlDeviceGetPerformanceState(gpu_device)
+        try:
+            int(state)
+            return "P%s" % state
+        except ValueError:
+            return state
+    elif (metric == 'graphics_clock_report'):
+        return nvmlDeviceGetClockInfo(gpu_device, NVML_CLOCK_GRAPHICS)
+    elif (metric == 'sm_clock_report'):
+        return nvmlDeviceGetClockInfo(gpu_device, NVML_CLOCK_SM)
+    elif (metric == 'mem_clock_report'):
+        return nvmlDeviceGetClockInfo(gpu_device, NVML_CLOCK_MEM)
+    elif (metric == 'max_graphics_clock'):
+        return nvmlDeviceGetMaxClockInfo(gpu_device, NVML_CLOCK_GRAPHICS)
+    elif (metric == 'max_sm_clock'):
+        return nvmlDeviceGetMaxClockInfo(gpu_device, NVML_CLOCK_SM)
+    elif (metric == 'max_mem_clock'):
+        return nvmlDeviceGetMaxClockInfo(gpu_device, NVML_CLOCK_MEM)
+    elif (metric == 'power_usage_report'):
+        return nvmlDeviceGetPowerUsage(gpu_device)/1000
+    elif (metric == 'serial'):
+        return nvmlDeviceGetSerial(gpu_device)
+    elif (metric == 'power_man_mode'):
+        pow_man_mode = nvmlDeviceGetPowerManagementMode(gpu_device)
+        if (NVML_FEATURE_DISABLED == pow_man_mode):
+           return "OFF"
+        elif (NVML_FEATURE_ENABLED == pow_man_mode):
+           return "ON"
+        else:
+            return "UNKNOWN"
+    elif (metric == 'power_man_limit'):
+        powerLimit = nvmlDeviceGetPowerManagementLimit(gpu_device)
+        return powerLimit/1000
+    elif (metric == 'ecc_db_error'):
+        eccCount =  nvmlDeviceGetTotalEccErrors(gpu_device, 1, 1) 
+        return eccCount
+    elif (metric == 'ecc_sb_error'):
+        eccCount =  nvmlDeviceGetTotalEccErrors(gpu_device, 0, 1)
+        return eccCount
+    elif (metric == 'bar1_memory'):
+	memory =  nvmlDeviceGetBAR1MemoryInfo(gpu_device)
+        return int(memory.bar1Used/1000000)
+    elif (metric == 'bar1_max_memory'):
+        memory =  nvmlDeviceGetBAR1MemoryInfo(gpu_device)
+        return int(memory.bar1Total/1000000)
+    elif (metric == 'shutdown_temp'):
+        return nvmlDeviceGetTemperatureThreshold(gpu_device,0)
+    elif (metric == 'slowdown_temp'):
+        return nvmlDeviceGetTemperatureThreshold(gpu_device,1)
+    elif (metric == 'encoder_util'):
+        return int(nvmlDeviceGetEncoderUtilization(gpu_device)[0])
+    elif (metric == 'decoder_util'):
+        return int(nvmlDeviceGetDecoderUtilization(gpu_device)[0])
+    elif (metric == 'power_violation_report'):
+       violationData = nvmlDeviceGetViolationStatus(gpu_device, 0)
+       newTime = violationData.violationTime
+       
+       if (violation_dur[gpu_id] == 0):
+          violation_dur[gpu_id] = newTime
+      
+       diff = newTime - violation_dur[gpu_id]
+       # % calculation (diff/10)*100/10^9
+       rate = diff / 100000000
+       violation_dur[gpu_id] = newTime
+       print rate
+       return rate
+    elif (metric == 'process'):
+        procs = nvmlDeviceGetComputeRunningProcesses(gpu_device)
+        return len(procs)
+    else:
+        print "Handler for %s not implemented, please fix in gpu_device_handler()" % metric
+        os._exit(1)
+
+def metric_init(params):
+    global descriptors
+
+    try:
+        nvmlInit()
+    except NVMLError, err:
+        print "Failed to initialize NVML:", str(err)
+        print "Exiting..."
+        os._exit(1)
+
+    default_time_max = 90
+
+    build_descriptor('gpu_num', gpu_num_handler, default_time_max, 'uint', 'GPUs', 'zero', '%u', 'Total number of GPUs', 'gpu')
+    build_descriptor('gpu_use_num', gpu_num_handler, default_time_max, 'uint', 'GPUs', 'zero', '%u', 'Total number of Use  GPUs', 'gpu')
+    build_descriptor('gpu_driver', gpu_driver_version_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU Driver Version', 'gpu')
+
+    for i in range(get_gpu_num()):
+        build_descriptor('gpu%s_type' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Type' % i, 'gpu')
+        build_descriptor('gpu%s_graphics_clock_report' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'both', '%u', 'GPU%s Graphics Clock' % i, 'gpu')
+        build_descriptor('gpu%s_sm_clock_report' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'both', '%u', 'GPU%s SM Clock' % i, 'gpu')
+        build_descriptor('gpu%s_mem_clock_report' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'both', '%u', 'GPU%s Memory Clock' % i, 'gpu')
+        build_descriptor('gpu%s_uuid' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s UUID' % i, 'gpu')
+        build_descriptor('gpu%s_pci_id' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s PCI ID' % i, 'gpu')
+        build_descriptor('gpu%s_temp' % i, gpu_device_handler, default_time_max, 'uint', 'C', 'both', '%u', 'Temperature of GPU %s' % i, 'gpu,temp')
+        build_descriptor('gpu%s_mem_total' % i, gpu_device_handler, default_time_max, 'uint', 'MB', 'zero', '%u', 'GPU%s FB Memory Total' %i, 'gpu')
+        build_descriptor('gpu%s_fb_memory' % i, gpu_device_handler, default_time_max, 'uint', 'MB', 'both', '%u', 'GPU%s FB Memory Used' %i, 'gpu')
+        build_descriptor('gpu%s_ecc_mode' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s ECC Mode' %i, 'gpu')
+        #build_descriptor('gpu%s_perf_state' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Performance State' %i, 'gpu')
+        build_descriptor('gpu%s_util' % i, gpu_device_handler, default_time_max, 'uint', '%', 'both', '%u', 'GPU%s Utilization' %i, 'gpu')
+        build_descriptor('gpu%s_mem_util' % i, gpu_device_handler, default_time_max, 'uint', '%', 'both', '%u', 'GPU%s Memory Utilization' %i, 'gpu')
+        build_descriptor('gpu%s_fan' % i, gpu_device_handler, default_time_max, 'uint', '%', 'both', '%u', 'GPU%s Fan Speed' %i, 'gpu')
+        build_descriptor('gpu%s_power_usage_report' % i, gpu_device_handler, default_time_max, 'uint', 'watts', 'both', '%u', 'GPU%s Power Usage' % i, 'gpu')
+
+        # Added for version 2.285
+        build_descriptor('gpu%s_max_graphics_clock' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'zero', '%u', 'GPU%s Max Graphics Clock' % i, 'gpu')
+        build_descriptor('gpu%s_max_sm_clock' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'zero', '%u', 'GPU%s Max SM Clock' % i, 'gpu')
+        build_descriptor('gpu%s_max_mem_clock' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'zero', '%u', 'GPU%s Max Memory Clock' % i, 'gpu')
+        build_descriptor('gpu%s_serial' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Serial' % i, 'gpu')
+        #build_descriptor('gpu%s_power_man_mode' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Power Management' % i, 'gpu')
+        
+        # Driver version 340.25
+        build_descriptor('gpu%s_power_man_limit' % i, gpu_device_handler, default_time_max, 'uint', 'Watts', 'zero', '%u', 'GPU%s Power Management Limit' % i, 'gpu')
+        build_descriptor('gpu%s_ecc_db_error' % i, gpu_device_handler, default_time_max, 'uint', 'No Of Errors', 'both', '%u', 'GPU%s ECC Report' % i, 'gpu')
+        build_descriptor('gpu%s_ecc_sb_error' % i, gpu_device_handler, default_time_max, 'uint', 'No Of Errors', 'both', '%u', 'GPU%s Single Bit ECC' % i, 'gpu')
+        build_descriptor('gpu%s_power_violation_report' % i, gpu_device_handler, default_time_max, 'uint', '', 'both', '%u', 'GPU%s Power Violation Report' % i, 'gpu')
+        build_descriptor('gpu%s_bar1_memory' % i, gpu_device_handler, default_time_max, 'uint', 'MB', 'both', '%u', 'GPU%s Bar1 Memory Used' % i, 'gpu')
+        build_descriptor('gpu%s_bar1_max_memory' % i, gpu_device_handler, default_time_max, 'uint', 'MB', 'zero', '%u', 'GPU%s Bar1 Memory Total' % i, 'gpu')
+        build_descriptor('gpu%s_shutdown_temp' % i, gpu_device_handler, default_time_max, 'uint', 'C', 'zero', '%u', 'GPU%s Type' % i, 'gpu')
+        build_descriptor('gpu%s_slowdown_temp' % i, gpu_device_handler, default_time_max, 'uint', 'C', 'zero', '%u', 'GPU%s Type' % i, 'gpu')
+        build_descriptor('gpu%s_encoder_util' % i, gpu_device_handler, default_time_max, 'uint', '%', 'both', '%u', 'GPU%s Type' % i, 'gpu')
+        build_descriptor('gpu%s_decoder_util' % i, gpu_device_handler, default_time_max, 'uint', '%', 'both', '%u', 'GPU%s Type' % i, 'gpu')
+    return descriptors
+
+def metric_cleanup():
+    '''Clean up the metric module.'''
+    try:
+        nvmlShutdown()
+    except NVMLError, err:
+        print "Error shutting down NVML:", str(err)
+        return 1
+
+#This code is for debugging and unit testing
+if __name__ == '__main__':
+    metric_init({})
+    for d in descriptors:
+        v = d['call_back'](d['name'])
+        if d['value_type'] == 'uint':
+            print 'value for %s is %u %s' % (d['name'], v, d['units'])
+        elif d['value_type'] == 'float' or d['value_type'] == 'double':
+            print 'value for %s is %f %s' % (d['name'], v, d['units'])
+        elif d['value_type'] == 'string':
+            print 'value for %s is %s %s' % (d['name'], v, d['units'])
+    metric_cleanup()

--- a/Databricks/ganglia/python_modules/nvidia.py
+++ b/Databricks/ganglia/python_modules/nvidia.py
@@ -216,7 +216,7 @@ def gpu_device_handler(name):
         return len(procs)
     else:
         print "Handler for %s not implemented, please fix in gpu_device_handler()" % metric
-        os._exit(1)
+        os._exit(0)
 
 def metric_init(params):
     global descriptors
@@ -225,8 +225,8 @@ def metric_init(params):
         nvmlInit()
     except NVMLError, err:
         print "Failed to initialize NVML:", str(err)
-        print "Exiting..."
-        os._exit(1)
+        print "GPU metrics will not be collected..."
+        return descriptors
 
     default_time_max = 90
 
@@ -290,4 +290,5 @@ if __name__ == '__main__':
             print 'value for %s is %f %s' % (d['name'], v, d['units'])
         elif d['value_type'] == 'string':
             print 'value for %s is %s %s' % (d['name'], v, d['units'])
-    metric_cleanup()
+    if descriptors:
+        metric_cleanup()

--- a/Databricks/ganglia/python_modules/nvidia.py
+++ b/Databricks/ganglia/python_modules/nvidia.py
@@ -1,4 +1,21 @@
+
 # NVIDIA GPU metric module using the Python bindings for NVML
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Portions of this file are copied/derived from
+# https://github.com/ganglia/gmond_python_modules/blob/master/gpu/nvidia/python_modules/nvidia.py
 #
 # (C)opyright 2011, 2012 Bernard Li <bernard@vanhpc.org>
 # All Rights Reserved.


### PR DESCRIPTION
This adds the GPU metrics to the Databricks Docker container via Ganglia. You can access them by clicking the Metrics tab in the Cluster UI and clicking the Ganglia UI link on that page.

<!--

Thank you for contributing to Docker container of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
