### PR TITLE
Fix defaults to re-enable DPP

### DIFF
--- a/Databricks/00-custom-spark-driver-defaults.conf
+++ b/Databricks/00-custom-spark-driver-defaults.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  "spark.plugins" = "com.nvidia.spark.SQLPlugin"
  "spark.rapids.memory.pinnedPool.size" = "2G"
  "spark.databricks.delta.optimizeWrite.enabled" = "false"
- "spark.sql.optimizer.dynamicPartitionPruning.enabled" = "false"
  "spark.sql.files.maxPartitionBytes" = "512m"
  "spark.rapids.sql.concurrentGpuTasks" = "2"
 }


### PR DESCRIPTION
Now that DPP has been fixed in Databricks as of release 22.12, these defaults need to be updated to allow DPP to remain enabled as the default.  

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to Docker container of RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
